### PR TITLE
Support using custom command triggers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This will send a list of installed VS Code themes to the requestor via whisper.
 !theme
 ```
 
-`Note: Only 1 whisper per user will be sent per day.`
+> Note: Only 1 whisper per user will be sent per day.
 
 #### Send response to chat of current theme
 
@@ -55,7 +55,7 @@ This command will set the theme of the streamers' VS Code workspace to the theme
 !theme {theme name}
 ```
 
-`Note: The theme must be previously installed and available within VS Code.`
+> Note: The theme must be previously installed and available within VS Code.
 
 #### Set Random VS Code theme
 
@@ -74,7 +74,7 @@ This command will set the theme of the streamers' VS Code workspace back to the 
 !theme reset
 ```
 
-`Note: Everytime the extension disconnects from chat, the theme will be reset.`
+> Note: Everytime the extension disconnects from chat, the theme will be reset.
 
 #### Refresh VS Code themes
 
@@ -84,7 +84,7 @@ This command will refresh the list of available themes in the streamers VS Code 
 !theme refresh
 ```
 
-`Note: List of themes and request timers will only be reset if the command is sent from the broadcaster.`
+> Note: List of themes and request timers will only be reset if the command is sent from the broadcaster.
 
 #### Install VS Code themes
 
@@ -94,7 +94,7 @@ This command will look for the specified theme on the Visual Studio Marketplace.
 !theme install {Theme Unique Identifier}
 ```
 
-`Example: For the [Linux Themes for VS Code](https://marketplace.visualstudio.com/items?itemName=solarliner.linux-themes) extension you would send !theme install solarliner.linux-themes`
+> **Example**: For the [Linux Themes for VS Code](https://marketplace.visualstudio.com/items?itemName=solarliner.linux-themes) extension, you would send `!theme install solarliner.linux-themes`
 
 
 #### Ban/Unban user from changing themes
@@ -107,7 +107,7 @@ These commands will either ban or unban a user from changing the theme via Twitc
 !theme !ban {username}
 ```
 
-`Note: List of banned users will reset on extension activation/start up.`
+> Note: List of banned users will reset on extension activation/start up.
 
 ----
 
@@ -121,6 +121,35 @@ These commands will either ban or unban a user from changing the theme via Twitc
 #### Access State
 
 On the settings UI, you can specify whether the extension should only react to all viewers, only followers or only subscribers.
+
+#### Auto Connect
+
+This setting will toggle whether the extension will automatically connect to Twitch when you launch Visual Studio Code.
+
+#### Auto Install
+
+This setting will toggle whether the extension will automatically install requested themes or show a prompt.
+
+#### Command Triggers
+
+You can change the trigger commands for the bot. For example, you can change `!theme` to `!colour` by changing the **Theme Command** setting.
+
+---
+
+### Available Triggers
+
+Trigger|Example|Description
+-|-|-
+theme|!theme|The main trigger for the bot
+ban|!theme ban {username}|This will ban a user from using the command
+current|!theme current|The bot will say the current in chat
+help|!theme help|The bot will give some guidance in chat
+install|!theme install {theme-unique-id}|Installs a theme extension
+random|!theme random|Randomly changes the theme of vscode
+dark|!theme random dark|Randomly chooses a dark theme
+light|!theme random light|Randomly chooses a light theme
+refresh|!theme refresh|Refreshes the currently install themes
+repo|!theme repo|The bot will say the repo location for this extension
 
 ----
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,66 @@
           "type": "boolean",
           "default": false,
           "description": "Should Twitch Themer automatically connect to Twitch Chat if you're streaming? Twitch Themer will poll Twitch' API to ensure you're streaming prior to connecting."
+        },
+        "twitchThemer.themeCommand": {
+          "title": "Theme Command",
+          "type": "string",
+          "default": "theme",
+          "description": "The command trigger to use."
+        },
+        "twitchThemer.installCommand": {
+          "title": "Install SubCommand",
+          "type": "string",
+          "default": "install",
+          "description": "The install sub-command trigger to use."
+        },
+        "twitchThemer.currentCommand": {
+          "title": "Current SubCommand",
+          "type": "string",
+          "default": "current",
+          "description": "The current sub-command trigger to use."
+        },
+        "twitchThemer.helpCommand": {
+          "title": "Help SubCommand",
+          "type": "string",
+          "default": "help",
+          "description": "The help sub-command trigger to use."
+        },
+        "twitchThemer.refreshCommand": {
+          "title": "Refresh SubCommand",
+          "type": "string",
+          "default": "refresh",
+          "description": "The refresh sub-command trigger to use."
+        },        
+        "twitchThemer.repoCommand": {
+          "title": "Repo SubCommand",
+          "type": "string",
+          "default": "repo",
+          "description": "The repo sub-command trigger to use."
+        },
+        "twitchThemer.banCommand": {
+          "title": "Ban SubCommand",
+          "type": "string",
+          "default": "ban",
+          "description": "The ban sub-command trigger to use."
+        },
+        "twitchThemer.random": {
+          "title": "Random SubCommand",
+          "type": "string",
+          "default": "random",
+          "description": "The random sub-command trigger to use."
+        },
+        "twitchThemer.dark": {
+          "title": "Dark SubCommand",
+          "type": "string",
+          "default": "dark",
+          "description": "The 'dark' sub-command trigger to use."
+        },
+        "twitchThemer.light": {
+          "title": "Light SubCommand",
+          "type": "string",
+          "default": "light",
+          "description": "The 'light' sub-command trigger to use."
         }
       }
     }

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -1,5 +1,5 @@
 import { ComfyJSInstance, OnCommandExtra, OnJoinExtra, OnMessageFlags } from "comfy.js";
-import { ConfigurationChangeEvent, EventEmitter, Memento, workspace } from 'vscode';
+import { ConfigurationChangeEvent, EventEmitter, Memento, workspace, WorkspaceConfiguration } from 'vscode';
 import { IChatMessage } from './IChatMessage';
 import { keytar } from '../Common';
 import { KeytarKeys } from '../Enum';
@@ -15,7 +15,7 @@ export default class ChatClient {
   
   private chatClientMessageEventEmitter = new EventEmitter<IChatMessage>();
   private chatClientConnectionEventEmitter = new EventEmitter<boolean>();
-  private _commandTrigger: string;
+  private _commandTrigger: string = "theme";
 
   /** Event that fires when an appropriate message is received */
   public onChatMessageReceived = this.chatClientMessageEventEmitter.event;
@@ -28,14 +28,18 @@ export default class ChatClient {
    * @param _state - The global state of the extension
    */
   constructor(_state: Memento, private logger: Logger) {
-    // this.ConfyJS = require('comfy.js');
-    this._commandTrigger = workspace.getConfiguration().get<string>('twitchThemer.themeCommand') || "theme"
+    this.initCmdTrigger()
     // If this extension configuration changes, ensure the command trigger is updated
     workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
       if (e.affectsConfiguration('twitchThemer')) {
-        this._commandTrigger = workspace.getConfiguration().get<string>('twitchThemer.themeCommand') || "theme"
+        this.initCmdTrigger()
       }
     });
+  }
+
+  private initCmdTrigger() {
+    const configuration: WorkspaceConfiguration = workspace.getConfiguration('twitchThemer');
+    this._commandTrigger = configuration.get<string>('themeCommand') || "theme"
   }
 
   /**
@@ -108,7 +112,7 @@ export default class ChatClient {
   private onJoinHandler(user: string, self: boolean, extra: OnJoinExtra) {
     if (self) {
       this.sendMessage(
-        'Twitch Themer is ready to go. Listening for commands beginning with !theme'
+        `Twitch Themer is ready to go. Listening for commands beginning with !${this._commandTrigger}`
       );
     }
   }

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -1,4 +1,4 @@
-import ComfyJS, { OnCommandExtra, OnJoinExtra, OnMessageFlags } from "comfy.js";
+import { ComfyJSInstance, OnCommandExtra, OnJoinExtra, OnMessageFlags } from "comfy.js";
 import { ConfigurationChangeEvent, EventEmitter, Memento, workspace } from 'vscode';
 import { IChatMessage } from './IChatMessage';
 import { keytar } from '../Common';
@@ -6,11 +6,13 @@ import { KeytarKeys } from '../Enum';
 import { IWhisperMessage } from './IWhisperMessage';
 import { Logger } from '../Logger';
 
+const ComfyJS: ComfyJSInstance = require('comfy.js');
+
 /**
  * Twitch chat client used in communicating via chat/whispers
  */
 export default class ChatClient {
-
+  
   private chatClientMessageEventEmitter = new EventEmitter<IChatMessage>();
   private chatClientConnectionEventEmitter = new EventEmitter<boolean>();
   private _commandTrigger: string;
@@ -26,6 +28,7 @@ export default class ChatClient {
    * @param _state - The global state of the extension
    */
   constructor(_state: Memento, private logger: Logger) {
+    // this.ConfyJS = require('comfy.js');
     this._commandTrigger = workspace.getConfiguration().get<string>('twitchThemer.themeCommand') || "theme"
     // If this extension configuration changes, ensure the command trigger is updated
     workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
@@ -94,7 +97,7 @@ export default class ChatClient {
 
   /** Is the client currently connected to Twitch chat */
   public isConnected(): boolean {
-    const client = ComfyJS ? ComfyJS.GetClient() : undefined
+    const client = ComfyJS.GetClient();
     return client ? client.readyState() === 'OPEN' : false;
   }
 

--- a/src/commands/ICommand.ts
+++ b/src/commands/ICommand.ts
@@ -1,0 +1,3 @@
+export interface ICommand {
+  [index: string]: string;
+}

--- a/src/commands/Themer.ts
+++ b/src/commands/Themer.ts
@@ -340,15 +340,15 @@ export class Themer {
 
   private initCommands() {
     const configuration = vscode.workspace.getConfiguration('twitchThemer');
-    this._commands['install'] = configuration.get<string>("twitchThemer.installCommand") || "install";
-    this._commands['current'] = configuration.get<string>("twitchThemer.currentCommand") || "current";
-    this._commands['help'] = configuration.get<string>("twitchThemer.helpCommand") || "help";
-    this._commands['random'] = configuration.get<string>("twitchThemer.randomCommand") || "random";
-    this._commands['dark'] = configuration.get<string>("twitchThemer.darkCommand") || "dark";
-    this._commands['light'] = configuration.get<string>("twitchThemer.lightCommand") || "light";
-    this._commands['refresh'] = configuration.get<string>("twitchThemer.refreshCommand") || "refresh";
-    this._commands['repo'] = configuration.get<string>("twitchThemer.repoCommand") || "repo";
-    this._commands['ban'] = configuration.get<string>("twitchThemer.banCommand") || "ban";
+    this._commands['install'] = configuration.get<string>("installCommand") || "install";
+    this._commands['current'] = configuration.get<string>("currentCommand") || "current";
+    this._commands['help'] = configuration.get<string>("helpCommand") || "help";
+    this._commands['random'] = configuration.get<string>("randomCommand") || "random";
+    this._commands['dark'] = configuration.get<string>("darkCommand") || "dark";
+    this._commands['light'] = configuration.get<string>("lightCommand") || "light";
+    this._commands['refresh'] = configuration.get<string>("refreshCommand") || "refresh";
+    this._commands['repo'] = configuration.get<string>("repoCommand") || "repo";
+    this._commands['ban'] = configuration.get<string>("banCommand") || "ban";
   }
 
   private async loadThemes() {


### PR DESCRIPTION
This PR seeks to allow broadcasters to choose the triggers used for the themer bot. For example, instead of using `!theme` as the command trigger, you could configure your settings to use `!tema` instead.

### Triggers

- theme
- install
- current
- help
- refresh
- repo
- ban
- random [ dark | light ]


 Solves #134